### PR TITLE
Improve dependency graph generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ string with:
 
 ### Stanford Dependencies
 
-	(dependency-graph "I like cheese.")
+	(dependency-graph (dependency-parse (tokenize "I like cheese.")))
 
 will parse the sentence and return the dependency graph as a
 [loom](https://github.com/jkk/loom) graph, which you can then traverse with

--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,7 @@
                  [edu.stanford.nlp/stanford-corenlp "3.5.2"]
                  [edu.stanford.nlp/stanford-corenlp "3.5.2" :classifier "models"]
                  [aysylu/loom  "0.5.4"]]
-  :plugins [[lein-exec "0.3.5"]
-            [lein-gorilla  "0.3.4"]]
+  :plugins [[lein-exec "0.3.5"]]
   :url "https://github.com/arnaudsj/stanford-corenlp"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,9 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [edu.stanford.nlp/stanford-corenlp "3.5.2"]
                  [edu.stanford.nlp/stanford-corenlp "3.5.2" :classifier "models"]
-                 [cc.artifice/loom "0.1.3"]]
-  :plugins [[lein-exec "0.3.5"]]
+                 [aysylu/loom  "0.5.4"]]
+  :plugins [[lein-exec "0.3.5"]
+            [lein-gorilla  "0.3.4"]]
   :url "https://github.com/arnaudsj/stanford-corenlp"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}

--- a/src/corenlp.clj
+++ b/src/corenlp.clj
@@ -194,14 +194,18 @@
 
 (defn dependency-graph [dp]
   "Produce a loom graph from a DependencyParse record."
-  (let [[words tags edges] (map #(% dp) [:words :tags :edges])
-        g (apply digraph (map (partial take 2) edges))]
+  (let [dependencies  (:edges dp)
+        g             (apply digraph (map (partial take 2) dependencies))
+        node-vec      (vec (remove neg? (nodes g)))
+        on-graph      (fn [dp-keyword] (map (vec (map-indexed vector (dp-keyword dp))) node-vec))
+        graph-words   (on-graph :words)
+        graph-tags    (on-graph :tags)]
     (reduce (fn [g [i t]] (add-attr g i :tag t))
             (reduce (fn [g [i w]] (add-attr g i :word w))
                     (reduce (fn [g [gov dep type]]
-                              (add-attr g gov dep :type type)) g edges)
-                    (map-indexed vector words))
-            (map-indexed vector tags))))
+                              (add-attr g gov dep :type type)) g dependencies)
+                    graph-words)
+            graph-tags)))
 
 (def dependency-parse nil)
 

--- a/test/corenlp/parsing_test.clj
+++ b/test/corenlp/parsing_test.clj
@@ -1,6 +1,7 @@
 (ns corenlp.parsing-test
   (:use clojure.test)
-  (:require [corenlp]))
+  (:require [corenlp]
+            [loom.graph :as lg]))
 
 
 
@@ -26,3 +27,9 @@
   "Named Entity Recognition"
   (is (= '("PERSON" "PERSON" "O" "O" "O" "O" "O" "LOCATION" "LOCATION" "O")
          (corenlp/named-entities "Barack Obama is the president of the United States."))))
+
+(deftest dependency-graph-test
+  "Loom dependency graph"
+  (let [dp (corenlp/dependency-parse (corenlp/tokenize "Me, and you, like cheese (a lot)."))]
+    (is (= #{0 -1 6 3 2 9 5 8}
+           (lg/nodes (corenlp/dependency-graph dp))))))


### PR DESCRIPTION
The `dependency-graph` did not work with text that contained any punctuation (like: `.,(` etc.). Now it should work, as the labels are not added to non-existent nodes.
